### PR TITLE
Fix PHP version requirement rule in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     ],
     "license": "BSD-2-Clause",
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "illuminate/contracts": "^5.1",
         "illuminate/support": "^5.1",
         "illuminate/http": "^5.1",


### PR DESCRIPTION
The library requires PHP 7.1 since v0.2.0, but composer.json php rule was not updated.
Fixed composer.json to require PHP 7.1.

Fixes #3 