### PR TITLE
Add support for API resource on laravel 5.5 and above

### DIFF
--- a/src/Server/Server.php
+++ b/src/Server/Server.php
@@ -167,7 +167,7 @@ class Server implements ServerInterface, RequestExecutorInterface
                 }
             );
 
-            return $request->getId() ? new RequestResponse($request->getId(), $result) : null;
+            return $request->getId() ? new RequestResponse($request->getId(), $result instanceof JsonResponse ? $result->getData() : $result) : null;
         } catch (JsonRpcException $e) {
             return $request->getId() ? RequestResponse::constructExceptionErrorResponse($request->getId(), $e) : null;
         } catch (\Exception $e) {


### PR DESCRIPTION
Add support for API resource on laravel 5.5 and above, which is useful when creating the model-based data structure.