### PR TITLE
Support for Laravel 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,18 +8,18 @@
     "license": "BSD-2-Clause",
     "require": {
         "php": ">=7.2",
-        "illuminate/contracts": "^5.1 || ^6",
-        "illuminate/support": "^5.1 || ^6",
-        "illuminate/http": "^5.1 || ^6",
-        "illuminate/pipeline": "^5.1 || ^6",
+        "illuminate/contracts": "^5.1 || ^6 || ^7",
+        "illuminate/support": "^5.1 || ^6 || ^7",
+        "illuminate/http": "^5.1 || ^6 || ^7",
+        "illuminate/pipeline": "^5.1 || ^6 || ^7",
         "psr/log": "^1.0",
         "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "~8.2",
-        "illuminate/validation": "^5.1 || ^6",
-        "illuminate/translation": "^5.1 || ^6",
-        "illuminate/container": "^5.1 || ^6"
+        "illuminate/validation": "^5.1 || ^6 || ^7",
+        "illuminate/translation": "^5.1 || ^6 || ^7",
+        "illuminate/container": "^5.1 || ^6 || ^7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This pull request adds support for the Laravel 7.x by supporting the `illuminate/*:^7` packages in `composer.json`.

I've personally tested it out and it works flawlessly on the latest version (`7.15.0`).