### PR TITLE
Feature: middleware params

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ class RouteServiceProvider extends ServiceProvider
 ```php
 $router->post('/jsonrpc', function (Illuminate\Http\Request $request) use ($jsonRpcServer) {
     $jsonRpcServer->router()
-        ->addMiddlewares(['fooMiddleware', 'barMiddleware']) // middleware alias names or class names
+        ->addMiddlewares(['fooMiddleware', 'barMiddleware', 'auth:rpcGuard']) // Middleware alias names or class names.
+                                                                              // Parameters may be specified by separating
+                                                                              // the middleware name and parameters with a :
         ->bindController('foo', 'FooController') // for 'foo.$method' methods invoke FooController->$method(),
                                                  // for 'foo' method invoke FooConroller->index()
         ->bind('bar', 'MyController@bar') // for 'bar' method invoke MyController->bar()

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
         "illuminate/http": "^5.1 || ^6 || ^7 || ^8",
         "illuminate/pipeline": "^5.1 || ^6 || ^7 || ^8",
         "psr/log": "^1.0",
-        "ext-json": "*",
-        "ext-mbstring": "*"
+        "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "~8.2",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "illuminate/http": "^5.1 || ^6 || ^7 || ^8",
         "illuminate/pipeline": "^5.1 || ^6 || ^7 || ^8",
         "psr/log": "^1.0",
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "~8.2",

--- a/src/Server/MiddlewareAliasRegistry.php
+++ b/src/Server/MiddlewareAliasRegistry.php
@@ -44,11 +44,13 @@ class MiddlewareAliasRegistry implements MiddlewareAliasRegistryInterface
      */
     public function findNameByAlias(string $alias): string
     {
-        if (!$this->aliasExists($alias)) {
+        [$aliasName, $aliasParams] = $this->parseAlias($alias);
+
+        if (!$this->aliasExists($aliasName)) {
             throw new \InvalidArgumentException("Middleware alias '$alias' has not been registered");
         }
 
-        return $this->registry[$alias];
+        return $this->registry[$aliasName] . (is_null($aliasParams)? '' : ":{$aliasParams}");
     }
 
     /**
@@ -67,7 +69,15 @@ class MiddlewareAliasRegistry implements MiddlewareAliasRegistryInterface
 
     private function aliasExists(string $alias): bool
     {
-        return isset($this->registry[$alias]);
+        [$aliasName,] = $this->parseAlias($alias);
+
+        return isset($this->registry[$aliasName]);
     }
 
+    private function parseAlias(string $alias): array
+    {
+        $parts = mb_split(':', $alias, 2);
+
+        return [$parts[0], $parts[1] ?? null];
+    }
 }

--- a/src/Server/MiddlewareAliasRegistry.php
+++ b/src/Server/MiddlewareAliasRegistry.php
@@ -50,7 +50,7 @@ class MiddlewareAliasRegistry implements MiddlewareAliasRegistryInterface
             throw new \InvalidArgumentException("Middleware alias '$alias' has not been registered");
         }
 
-        return $this->registry[$aliasName] . (is_null($aliasParams)? '' : ":{$aliasParams}");
+        return $this->registry[$aliasName] . ($aliasParams === null ? '' : ":{$aliasParams}");
     }
 
     /**
@@ -76,7 +76,7 @@ class MiddlewareAliasRegistry implements MiddlewareAliasRegistryInterface
 
     private function parseAlias(string $alias): array
     {
-        $parts = mb_split(':', $alias, 2);
+        $parts = explode(":", $alias, 2);
 
         return [$parts[0], $parts[1] ?? null];
     }

--- a/tests/MiddlewareAliasRegistryTest.php
+++ b/tests/MiddlewareAliasRegistryTest.php
@@ -2,28 +2,29 @@
 declare(strict_types=1);
 
 use Upgate\LaravelJsonRpc\Server\MiddlewareAliasRegistry;
-use Upgate\LaravelJsonRpc\Contract\MiddlewaresConfigurationInterface;
 
 class MiddlewareAliasRegistryTest extends \PHPUnit\Framework\TestCase
 {
 
-    public function testMiddlewareAliasResolver()
+    public function testMiddlewareAliasResolver(): void
     {
-        /** @var MiddlewaresConfigurationInterface $middlewaresConfiguration */
-
         $middlewareAliasRegistry = new MiddlewareAliasRegistry();
         $middlewareAliasRegistry->registerAliases(
             [
                 'foo' => 'FooMiddleware',
-                'baz' => 'BazMiddleware'
+                'baz' => 'BazMiddleware',
+                'auth' => 'Authenticate',
             ]
         );
 
         $this->assertEquals('FooMiddleware', $middlewareAliasRegistry->findNameByAlias('foo'));
 
+        $this->assertEquals('Authenticate', $middlewareAliasRegistry->findNameByAlias('auth'));
+        $this->assertEquals('Authenticate:guard', $middlewareAliasRegistry->findNameByAlias('auth:guard'));
+
         $this->assertEquals(
-            ['FooMiddleware', 'BarMiddleware', 'BazMiddleware'],
-            $middlewareAliasRegistry->resolveAliases(['foo', 'BarMiddleware', 'baz'])
+            ['FooMiddleware', 'BarMiddleware', 'BazMiddleware', 'Authenticate', 'Authenticate:guard2', 'BazMiddleware:1,2'],
+            $middlewareAliasRegistry->resolveAliases(['foo', 'BarMiddleware', 'baz', 'Authenticate', 'auth:guard2', 'baz:1,2'])
         );
 
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
Hi! I'd like to propose little changes which are aimed to support middleware parameters both for class name and aliases. At least it can be useful for `auth` middleware.

Looking forward to your review.